### PR TITLE
Allow config to require other files

### DIFF
--- a/Phoenix/PHPathWatcher.h
+++ b/Phoenix/PHPathWatcher.h
@@ -11,5 +11,6 @@
 @interface PHPathWatcher : NSObject
 
 + (PHPathWatcher*) watcherFor:(NSString*)path handler:(void(^)())handler;
+- (NSString *) path;
 
 @end

--- a/Phoenix/PHPathWatcher.m
+++ b/Phoenix/PHPathWatcher.m
@@ -12,6 +12,7 @@
 
 @property FSEventStreamRef stream;
 @property (copy) void(^handler)();
+@property NSString *path;
 
 @end
 
@@ -34,11 +35,12 @@ void fsEventsCallback(ConstFSEventStreamRef streamRef, void *clientCallBackInfo,
 + (PHPathWatcher*) watcherFor:(NSString*)path handler:(void(^)())handler {
     PHPathWatcher* watcher = [[PHPathWatcher alloc] init];
     watcher.handler = handler;
-    [watcher setup:path];
+    watcher.path = path;
+    [watcher setup];
     return watcher;
 }
 
-- (void) setup:(NSString*)path {
+- (void) setup {
     FSEventStreamContext context;
     context.info = (__bridge void*)self;
     context.version = 0;
@@ -48,7 +50,7 @@ void fsEventsCallback(ConstFSEventStreamRef streamRef, void *clientCallBackInfo,
     self.stream = FSEventStreamCreate(NULL,
                                       fsEventsCallback,
                                       &context,
-                                      (__bridge CFArrayRef)@[[path stringByStandardizingPath]],
+                                      (__bridge CFArrayRef)@[[self.path stringByStandardizingPath]],
                                       kFSEventStreamEventIdSinceNow,
                                       0.4,
                                       kFSEventStreamCreateFlagWatchRoot | kFSEventStreamCreateFlagNoDefer | kFSEventStreamCreateFlagFileEvents);


### PR DESCRIPTION
@jasonm23 first of all thanks for maintaining this awesome project!

I'm using Phoenix on two machines and I wanted to be able to share generic configuration between the configurations of both my machines. This allows me to easily have machine specific configuration with most of the configuration shared between my machines.

This PR adds support for requiring/importing files into the `.phoenix.js` config file, in a node `require` fashion. This is useful for reusability of configuration snippets.

Required files are automatically watched for changes, just like the main
`.phoenix.js` config file.

Usage:

``` javascript
require('<path to some.js file>');
```

If the path is a relative path it's resolved relative to the (real)
location of the `.phoenix.js` file. If the `.phoenix.js` file is a symlink
the symlink is resolved before resolving the location of the required
file.

I would love to hear your feedback on my changes, is this something you would want to merge?
