### PR TITLE
Stop crashing due to exception 'must provide array of arguments' on api.runCommand()

### DIFF
--- a/Phoenix/PHConfigLoader.m
+++ b/Phoenix/PHConfigLoader.m
@@ -137,7 +137,10 @@ static NSString* PHConfigPath = @"~/.phoenix.js";
     api[@"runCommand"] = ^(NSString* path, NSArray *args) {
         NSTask *task = [[NSTask alloc] init];
 
-        [task setArguments:args];
+        if (args) {
+          [task setArguments:args];
+        }
+
         [task setLaunchPath:path];
         [task launch];
 


### PR DESCRIPTION
For example, when I add the following to my `~/.phoenix.js`:

``` javascript
api.runCommand("/bin/date");
```

Phoenix crashes. The console shows it is crashing rather than handling the exception of "must provide array of arguments" to `runCommand()`. One way around this (I'm no Objective-C expert) seems to be to only set the arguments on the command if they exist.

This commit stops the app from crashing.

Console crash log:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'must provide array of arguments'
abort() called
terminating with uncaught exception of type NSException
```
