### PR TITLE
Add support for script pre-processing via shebang/#!

### DIFF
--- a/API.md
+++ b/API.md
@@ -3,6 +3,16 @@ JavaScript API
 
 This documentation is an overview of the JavaScript API provided by Phoenix. Use this as a guide for writing your window management script. Your script should reside in `~/.phoenix.js`. Phoenix includes [Underscore.js](http://underscorejs.org) (1.8.3) — you can use its features in your configuration. Underscore provides useful helpers for handling JavaScript functions and objects.
 
+You may add JavaScript pre-processing to your `~/.phoenix.js` file by adding a [Shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) to the beginning of your file. For example, use [Babel](https://babeljs.io/) to pre-process ES2015 JavaScript syntax:
+```javascript
+#!/usr/bin/env babel
+const handlers = [];
+handlers.push(Phoenix.bind('c', ['alt', 'shift'], () => {
+  const app = App.launch('Google Chrome');
+  app.focus();
+}));
+```
+
 ## API
 
 1. [Keys](#1-keys)

--- a/Phoenix.xcodeproj/project.pbxproj
+++ b/Phoenix.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1C93D6641BE11FF100649405 /* PHScriptHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C93D6631BE11FF100649405 /* PHScriptHelper.m */; settings = {ASSET_TAGS = (); }; };
 		A7183B671B6E865F00842E13 /* PHKeyHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = A7183B661B6E865F00842E13 /* PHKeyHandler.m */; };
 		A72EAD041B5CE34800DD537B /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = A72EAD031B5CE34800DD537B /* Credits.rtf */; };
 		A72EAD071B5D00B800DD537B /* PHModalWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = A72EAD061B5D00B800DD537B /* PHModalWindowController.m */; };
@@ -48,6 +49,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1C93D6621BE11FF100649405 /* PHScriptHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PHScriptHelper.h; sourceTree = "<group>"; };
+		1C93D6631BE11FF100649405 /* PHScriptHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PHScriptHelper.m; sourceTree = "<group>"; };
 		A7183B651B6E865F00842E13 /* PHKeyHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PHKeyHandler.h; sourceTree = "<group>"; };
 		A7183B661B6E865F00842E13 /* PHKeyHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PHKeyHandler.m; sourceTree = "<group>"; };
 		A72A6B031B934C2000F2C4EF /* PHIdentifiableJSExport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PHIdentifiableJSExport.h; sourceTree = "<group>"; };
@@ -152,6 +155,8 @@
 				A79C468B1B5BF3C100C460CF /* PHOpenAtLoginHelper.m */,
 				A79C468E1B5BF3C100C460CF /* PHUniversalAccessHelper.h */,
 				A79C468F1B5BF3C100C460CF /* PHUniversalAccessHelper.m */,
+				1C93D6621BE11FF100649405 /* PHScriptHelper.h */,
+				1C93D6631BE11FF100649405 /* PHScriptHelper.m */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -405,6 +410,7 @@
 				A74133721BB7F556008DAF39 /* PHEventTranslator.m in Sources */,
 				A7E6DF6F1BBAC1F3001920B4 /* PHAccessibilityObserver.m in Sources */,
 				A79C46971B5BF3C100C460CF /* PHApp.m in Sources */,
+				1C93D6641BE11FF100649405 /* PHScriptHelper.m in Sources */,
 				A7D1D9A91B6FD6A300E00CC9 /* PHKeyTranslator.m in Sources */,
 				A79C46A01B5BF3C100C460CF /* PHWindow.m in Sources */,
 				A72EAD071B5D00B800DD537B /* PHModalWindowController.m in Sources */,

--- a/Phoenix/PHContext.m
+++ b/Phoenix/PHContext.m
@@ -11,6 +11,7 @@
 #import "PHModalWindowController.h"
 #import "PHMouse.h"
 #import "PHNotificationHelper.h"
+#import "PHScriptHelper.h"
 #import "PHPathWatcher.h"
 #import "PHPhoenix.h"
 #import "PHWindow.h"
@@ -88,7 +89,7 @@
 
 - (NSString *) resolvePath:(NSString *)path {
 
-    path = path.stringByStandardizingPath;
+    path = path.stringByResolvingSymlinksInPath;
 
     // Resolve path
     if(![path isAbsolutePath]) {
@@ -116,10 +117,12 @@
 
     NSError *error;
     NSString *script = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:&error];
-
+    
     if (error) {
         NSLog(@"Error: Could not read file in path “%@” to string. (%@)", path, error);
     }
+    
+    script = [PHScriptHelper preprocessScriptIfNeeded:script atPath:path];
 
     [self.context evaluateScript:script];
     [self.paths addObject:path];

--- a/Phoenix/PHScriptHelper.h
+++ b/Phoenix/PHScriptHelper.h
@@ -1,0 +1,13 @@
+/*
+ * Phoenix is released under the MIT License. Refer to https://github.com/kasper/phoenix/blob/master/LICENSE.md
+ */
+
+@import Foundation;
+
+@interface PHScriptHelper : NSObject
+
+#pragma mark - Script Preprocessing
+
++ (NSString * __nullable)preprocessScriptIfNeeded:(NSString * __nonnull)script atPath:(NSString * __nonnull)path;
+
+@end

--- a/Phoenix/PHScriptHelper.m
+++ b/Phoenix/PHScriptHelper.m
@@ -1,0 +1,49 @@
+/*
+ * Phoenix is released under the MIT License. Refer to https://github.com/kasper/phoenix/blob/master/LICENSE.md
+ */
+
+#import "PHScriptHelper.h"
+
+@implementation PHScriptHelper
+
+#pragma mark - Script Preprocessing
+
++ (NSString * __nullable)preprocessScriptIfNeeded:(NSString * __nonnull)script atPath:(NSString * __nonnull)path {
+    
+    NSScanner *scanner = [NSScanner scannerWithString:script];
+    
+    /* Return early if no shebang "#!" */
+    if (![scanner scanString:@"#!" intoString:NULL]) {
+        return script;
+    }
+    
+    NSString *preprocessCommand;
+    [scanner scanUpToCharactersFromSet:[NSCharacterSet newlineCharacterSet] intoString:&preprocessCommand];
+    
+    NSPipe *stdoutPipe = [NSPipe pipe];
+    NSPipe *stderrPipe = [NSPipe pipe];
+    
+    NSTask *task = [[NSTask alloc] init];
+    [task setLaunchPath:@"/bin/sh"];
+    [task setStandardOutput:stdoutPipe];
+    [task setStandardError:stderrPipe];
+    
+    [task setArguments:@[@"-c", [NSString stringWithFormat:@"%@ %@", preprocessCommand, path]]];
+    
+    NSFileHandle *stdoutFile = [stdoutPipe fileHandleForReading];
+    NSFileHandle *stderrFile = [stderrPipe fileHandleForReading];
+    [task launch];
+    
+    /* Log any stderr output to Console */
+    NSString *errorMessage = [[NSString alloc] initWithData:[stderrFile readDataToEndOfFile] encoding:NSUTF8StringEncoding];
+    if (errorMessage.length > 0) {
+        NSLog(@"Preprocessor error output: %@", errorMessage);
+    }
+    
+    /* Read past the shebang line to prevent syntax error */
+    [stdoutFile readDataOfLength:2 + preprocessCommand.length];
+    
+    return [[NSString alloc] initWithData:[stdoutFile readDataToEndOfFile] encoding:NSUTF8StringEncoding];
+}
+
+@end


### PR DESCRIPTION
This pull request adds support for generic pre-preprocessing of
JavaScript through the use of a shebang at the top of your Phoenix JS
config.

This also adds support for `~/.phoenix[-debug].js` being a symlink.

**Example:**
```javascript
#!/usr/bin/env babel
// ... Custom Phoenix JS
```