### PR TITLE
Fix inability to use symlinked config with relative includes

### DIFF
--- a/Phoenix/PHContext.m
+++ b/Phoenix/PHContext.m
@@ -88,11 +88,11 @@
 
 - (NSString *) resolvePath:(NSString *)path {
 
-    path = path.stringByStandardizingPath;
+    path = path.stringByResolvingSymlinksInPath;
 
     // Resolve path
     if(![path isAbsolutePath]) {
-        NSURL *relativeUrl = [NSURL URLWithString:PHConfigurationPath.stringByStandardizingPath];
+        NSURL *relativeUrl = [NSURL URLWithString:PHConfigurationPath.stringByResolvingSymlinksInPath];
         path = [NSURL URLWithString:path relativeToURL:relativeUrl].absoluteString;
     }
 


### PR DESCRIPTION
My Phoenix config is symlinked to `~/.phoenix.js` from my dotfiles
directory. This PR adds support for relative requires whether or not
you're using a symlinked config file, it also maintains support for
absoltue path includes (e.g. `require('~/jslibs/some-file.js')`).