### PR TITLE
Add -visibleWindows to the Screen API

### DIFF
--- a/API.md
+++ b/API.md
@@ -43,7 +43,7 @@ To combine, bind a key to move the focused window.
 ```javascript
 var handler = Phoenix.bind('q', [ 'ctrl', 'shift' ], function () {
 
-    Window.focusedWindow().setTopLeft({ x: 0, y: 0 }); 
+    Window.focusedWindow().setTopLeft({ x: 0, y: 0 });
 });
 ```
 
@@ -282,6 +282,8 @@ class Screen implements Identifiable
 
     Rectangle frameInRectangle()
     Rectangle visibleFrameInRectangle()
+    Array<Window> windows()
+    Array<Window> visibleWindows()
     Screen next()
     Screen previous()
 
@@ -292,6 +294,8 @@ end
 - `screens()` returns all screens, the first screen in this array corresponds to the primary screen for the system
 - `frameInRectangle()` returns the whole frame for the screen
 - `visibleFrameInRectangle()` returns the visible frame for the screen subtracting the Dock and Menu from the frame when visible
+- `windows()` returns all windows for the screen
+- `visibleWindows()` returns all visible windows for the screen, a visible window is a normal and unminimised window that belongs to an unhidden app
 - `next()` returns the next screen or the first screen when on the last one
 - `previous()` returns the previous screen or the last screen when on the first one
 

--- a/Phoenix/NSScreen+PHExtension.h
+++ b/Phoenix/NSScreen+PHExtension.h
@@ -6,6 +6,7 @@
 @import JavaScriptCore;
 
 #import "PHIdentifiableJSExport.h"
+#import "PHWindow.h"
 
 @protocol NSScreenJSExport <JSExport, PHIdentifiableJSExport>
 
@@ -23,6 +24,11 @@
 
 - (NSScreen *) next;
 - (NSScreen *) previous;
+
+#pragma mark - Windows
+
+- (NSArray<PHWindow *> *) windows;
+- (NSArray<PHWindow *> *) visibleWindows;
 
 @end
 

--- a/Phoenix/NSScreen+PHExtension.m
+++ b/Phoenix/NSScreen+PHExtension.m
@@ -4,6 +4,8 @@
 
 #import "NSScreen+PHExtension.h"
 
+#import "PHApp.h"
+
 @implementation NSScreen (PHExtension)
 
 #pragma mark - Frame
@@ -52,6 +54,38 @@
     }
     
     return screens[previousIndex];
+}
+
+#pragma mark - Windows
+
+- (NSArray<PHWindow *> *) windows {
+
+    NSMutableArray<PHWindow *> *windows = [NSMutableArray array];
+
+    for (PHApp *app in [PHApp runningApps]) {
+        [windows addObjectsFromArray:[app windows]];
+    }
+
+    NSPredicate *onScreen = [NSPredicate predicateWithBlock:^BOOL (PHWindow *window,
+                                                                   __unused NSDictionary<NSString *, id> *bindings) {
+
+        return [window.screen isEqualTo:self];
+    }];
+
+    return [windows filteredArrayUsingPredicate:onScreen];
+}
+
+- (NSArray<PHWindow *> *) visibleWindows {
+
+    NSArray<PHWindow *> *windows = [self windows];
+
+    NSPredicate *visibility = [NSPredicate predicateWithBlock:^BOOL (PHWindow *window,
+                                                                     __unused NSDictionary<NSString *, id> *bindings) {
+
+        return [window isVisible];
+    }];
+
+    return [windows filteredArrayUsingPredicate:visibility];
 }
 
 @end

--- a/Phoenix/PHApp.m
+++ b/Phoenix/PHApp.m
@@ -122,7 +122,7 @@
     NSPredicate *visibility = [NSPredicate predicateWithBlock:^BOOL (PHWindow *window,
                                                                      __unused NSDictionary<NSString *, id> *bindings) {
 
-        return ![[window app] isHidden] && [window isNormal] && ![window isMinimized];
+        return [window isVisible];
     }];
 
     return [[self windows] filteredArrayUsingPredicate:visibility];

--- a/Phoenix/PHWindow.h
+++ b/Phoenix/PHWindow.h
@@ -29,6 +29,7 @@
 - (BOOL) isMain;
 - (BOOL) isNormal;
 - (BOOL) isMinimized;
+- (BOOL) isVisible;
 - (PHApp *) app;
 - (NSScreen *) screen;
 

--- a/Phoenix/PHWindow.m
+++ b/Phoenix/PHWindow.m
@@ -62,7 +62,7 @@ AXError _AXUIElementGetWindow(AXUIElementRef, CGWindowID *out);
     NSPredicate *visibility = [NSPredicate predicateWithBlock:^BOOL (PHWindow *window,
                                                                      __unused NSDictionary<NSString *, id> *bindings) {
 
-        return ![window.app isHidden] && [window isNormal] && ![window isMinimized];
+        return [window isVisible];
     }];
 
     return [[self windows] filteredArrayUsingPredicate:visibility];
@@ -155,6 +155,11 @@ AXError _AXUIElementGetWindow(AXUIElementRef, CGWindowID *out);
 - (BOOL) isMinimized {
 
     return [[self valueForAttribute:NSAccessibilityMinimizedAttribute withDefaultValue:@NO] boolValue];
+}
+
+- (BOOL) isVisible {
+
+    return ![self.app isHidden] && [self isNormal] && ![self isMinimized];
 }
 
 - (NSScreen *) screen {


### PR DESCRIPTION
This provides a convenience for Phoenix configs that wish to enumerate the windows on a given screen.