### PR TITLE
Preprocessor shebang clipping fix

### DIFF
--- a/Phoenix/PHShebangPreprocessor.m
+++ b/Phoenix/PHShebangPreprocessor.m
@@ -74,10 +74,24 @@
         return script;
     }
 
-    // Read past shebang-directive
-    [standardOutputFile readDataOfLength:scanner.scanLocation];
+    // Read past shebang-directive (hold onto it incase it's not the shebang text)
+    NSString *outputHead = [[NSString alloc]
+                               initWithData:[standardOutputFile readDataOfLength:scanner.scanLocation]
+                                   encoding:NSUTF8StringEncoding];
+    // Read the rest of processed output
+    NSString *processed  = [[NSString alloc]
+                               initWithData:[standardOutputFile readDataToEndOfFile]
+                                   encoding:NSUTF8StringEncoding];
 
-    return [[NSString alloc] initWithData:[standardOutputFile readDataToEndOfFile] encoding:NSUTF8StringEncoding];
+    // return the output with shebang clipped
+    if ([command isEqualToString:outputHead]) {
+
+        return processed;
+
+    }
+
+    // otherwise glue it back together
+    return [outputHead stringByAppendingString:processed];
 }
 
 @end


### PR DESCRIPTION
RFC @shayne @kasper

When we capture the output from babel, coffee etc. it _should_ no longer include the shebang, so we should not read past that position.

Perhaps some preprocessors might leave in things like that? Please let me know if they do.

It would be a simple solve to just read past it, if it's there, but not blindly.