### PR TITLE
Get user shell from NSProcessInfo environment

### DIFF
--- a/Phoenix/PHShebangPreprocessor.m
+++ b/Phoenix/PHShebangPreprocessor.m
@@ -67,7 +67,11 @@
     NSPipe *standardError = [NSPipe pipe];
     NSFileHandle *standardOutputFile = standardOutput.fileHandleForReading;
 
-    task.launchPath = @"/bin/bash";
+    // Make sure we use the current user's $SHELL
+    NSDictionary *environmentDict = [[NSProcessInfo processInfo] environment];
+    NSString *shellString = [environmentDict objectForKey:@"SHELL"];
+
+    task.launchPath = shellString;
     task.standardOutput = standardOutput;
     task.standardError = standardError;
     task.arguments = @[ @"-cl", [NSString stringWithFormat:@"%@ %@", command, path] ];


### PR DESCRIPTION
We could apply this to `Command.run(...)` too, I'll take a look.

I successfully tested this with ZSH as `$SHELL` and this shebang for literate coffee:

    #!coffee -pl

( reminds me of using `#!perl` before we had all these neat web languages ;) )