### PR TITLE
Execute PHHandler js functions using the parent JSContext

### DIFF
--- a/Phoenix/PHHandler.m
+++ b/Phoenix/PHHandler.m
@@ -23,11 +23,7 @@
 
 - (void) callWithArguments:(NSArray *)arguments {
 
-    // Create a new scope for callback
-    JSValue *callback = self.callback.value;
-    JSContext *scope = [[JSContext alloc] initWithVirtualMachine:callback.context.virtualMachine];
-    JSValue *function = [JSValue valueWithObject:callback inContext:scope];
-
+    JSValue *function = self.callback.value;
     [function callWithArguments:arguments];
 }
 


### PR DESCRIPTION
Fixes #70; using the parent JSContext allows sharing the
default exceptionHandler.

@kasper as discussed in #70 I think this approach is preferable over sharing an exception handler. I couldn't find any memory leaks with this approach but please verify.