### PR TITLE
Add support for ISO section key

### DIFF
--- a/Phoenix/PHKeyTranslator.m
+++ b/Phoenix/PHKeyTranslator.m
@@ -120,7 +120,8 @@
                                                 @(kVK_ANSI_Comma),
                                                 @(kVK_ANSI_Slash),
                                                 @(kVK_ANSI_Period),
-                                                @(kVK_ANSI_Grave) ];
+                                                @(kVK_ANSI_Grave),
+                                                @(kVK_ISO_Section) ];
 
         localKeyToKeyCode = [NSMutableDictionary dictionary];
 


### PR DESCRIPTION
This PR adds support for the section key `§`. I'm an avid user of it myself as a terminal hotkey (`cmd+§`) and would like to see it supported.

Do you foresee any problems with this change @kasper? This is only available on ISO keyboards.