### PR TITLE
Add 'edit config file' menu item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Changelog
 
 Release: dd.mm.yyyy
 
+### New
+
+- Add “Edit configuration” status menu item ([#156](https://github.com/kasper/phoenix/pull/156)).
+
 2.4
 ---
 

--- a/Phoenix/Base.lproj/MainMenu.xib
+++ b/Phoenix/Base.lproj/MainMenu.xib
@@ -675,6 +675,12 @@
                         <action selector="reloadContext:" target="rNM-Wb-aci" id="E9f-eT-5pH"/>
                     </connections>
                 </menuItem>
+                <menuItem title="Edit configuration" id="Cl9-v8-MX6">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="editConfiguration:" target="rNM-Wb-aci" id="MyM-4W-7eP"/>
+                    </connections>
+                </menuItem>
                 <menuItem isSeparatorItem="YES" id="Pit-IP-uIm"/>
                 <menuItem title="About Phoenix" id="bgT-ei-lKc">
                     <modifierMask key="keyEquivalentModifierMask"/>
@@ -704,6 +710,7 @@
             <connections>
                 <outlet property="delegate" destination="rNM-Wb-aci" id="GyG-uy-eLr"/>
             </connections>
+            <point key="canvasLocation" x="131.5" y="165.5"/>
         </menu>
     </objects>
 </document>

--- a/Phoenix/PHAppDelegate.h
+++ b/Phoenix/PHAppDelegate.h
@@ -11,6 +11,7 @@
 #pragma mark - IBAction
 
 - (IBAction) reloadContext:(id)sender;
+- (IBAction) editConfiguration:(id)sender;
 - (IBAction) showAboutPanel:(id)sender;
 - (IBAction) toggleOpenAtLogin:(NSMenuItem *)sender;
 

--- a/Phoenix/PHAppDelegate.m
+++ b/Phoenix/PHAppDelegate.m
@@ -89,6 +89,12 @@
     [self.context load];
 }
 
+- (IBAction) editConfiguration:(id)__unused sender {
+
+    [[NSWorkspace sharedWorkspace] openFile:self.context.primaryConfigurationPath];
+}
+
+
 - (IBAction) showAboutPanel:(id)sender {
 
     [NSApp activateIgnoringOtherApps:YES];

--- a/Phoenix/PHContext.h
+++ b/Phoenix/PHContext.h
@@ -6,6 +6,8 @@
 
 @protocol PHContextDelegate <NSObject>
 
+@property (readonly) NSString *primaryConfigurationPath;
+
 #pragma mark - Loading
 
 - (void) load;


### PR DESCRIPTION
Added a menu item to open the current config file in the default editor.

This is my first attempt at an ObjC/OS X contribution, so obviously, I don't really know what I'm doing. But it works ¯\\\_(ツ)_/¯ :)

![screen shot 2016-12-22 at 13 25 34](https://cloud.githubusercontent.com/assets/844866/21424247/2dafff14-c84a-11e6-8419-5cd75889cf61.png)


- [x] Updated related documentations (none necessary)
- [x] Added the change to the Changelog

