### PR TITLE
README: remove reference to mjolnir

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If you have any questions, feedback or just want to say hi, you can open an issu
 
 ## Thanks
 
-Phoenix is currently developed by Kasper Hirvikoski ([@kasper](https://github.com/kasper/)) and Jason Milkins ([@jasonm23](https://github.com/jasonm23/)) with the generous help of contributions made by many [individuals](https://github.com/kasper/phoenix/graphs/contributors/). It was originally authored by Steven Degutis ([@sdegutis](https://github.com/sdegutis/)) as a fork of Zephyros — also an app of his. As it stands now, it has been rewritten from the ground up by Kasper Hirvikoski. Steven is continuing his work on macOS window management in [Mjolnir](https://github.com/sdegutis/mjolnir/).
+Phoenix is currently developed by Kasper Hirvikoski ([@kasper](https://github.com/kasper/)) and Jason Milkins ([@jasonm23](https://github.com/jasonm23/)) with the generous help of contributions made by many [individuals](https://github.com/kasper/phoenix/graphs/contributors/). It was originally authored by Steven Degutis ([@sdegutis](https://github.com/sdegutis/)) as a fork of Zephyros — also an app of his. As it stands now, it has been rewritten from the ground up by Kasper Hirvikoski.
 
 ## License
 


### PR DESCRIPTION
- [ ] Updated related documentations
- [ ] Added the change to the Changelog

↑ Not relevant since it’s a simple README change.

Mjolnir was last updated in September 2016, so saying work is continuing there might be innacurate.