### PR TITLE
Make app.launch() faster by introducing an option

### DIFF
--- a/Phoenix/PHApp.h
+++ b/Phoenix/PHApp.h
@@ -16,7 +16,7 @@
 #pragma mark - Apps
 
 + (instancetype) get:(NSString *)appName;
-+ (instancetype) launch:(NSString *)appName;
++ (instancetype) launch:(NSString *)appName :(NSDictionary<NSString *, id> *)optionals;
 + (instancetype) focused;
 + (NSArray<PHApp *> *) all;
 

--- a/Phoenix/PHApp.m
+++ b/Phoenix/PHApp.m
@@ -15,6 +15,7 @@
 @implementation PHApp
 
 static NSString * const PHAppForceOptionKey = @"force";
+static NSString * const PHAppLaunchFocusOptionKey = @"focus";
 
 #pragma mark - Initialising
 
@@ -41,7 +42,7 @@ static NSString * const PHAppForceOptionKey = @"force";
     return nil;
 }
 
-+ (instancetype) launch:(NSString *)appName {
++ (instancetype) launch:(NSString *)appName :(NSDictionary<NSString *, id> *)optionals {
 
     NSWorkspace *sharedWorkspace = [NSWorkspace sharedWorkspace];
     NSString *appPath = [sharedWorkspace fullPathForApplication:appName];
@@ -51,9 +52,16 @@ static NSString * const PHAppForceOptionKey = @"force";
         return nil;
     }
 
+    NSNumber *focusOption = optionals[PHAppLaunchFocusOptionKey];
+
+    NSWorkspaceLaunchOptions launchOption = NSWorkspaceLaunchWithoutActivation;
+    if (focusOption && focusOption.boolValue) {
+        launchOption = NSWorkspaceLaunchDefault;
+    }
+
     NSError *error;
     NSRunningApplication *app = [sharedWorkspace launchApplicationAtURL:[NSURL fileURLWithPath:appPath]
-                                                                options:NSWorkspaceLaunchWithoutActivation
+                                                                options:launchOption
                                                           configuration:@{}
                                                                   error:&error];
     if (error) {

--- a/docs/API.md
+++ b/docs/API.md
@@ -564,7 +564,7 @@ Use the `App`-object to control apps. Beware that an app can get stale if you ke
 class App implements Identifiable
 
   static App get(String appName)
-  static App launch(String appName)
+  static App launch(String appName, Map<String, AnyObject> optionals)
   static App focused()
   static Array<App> all()
 
@@ -587,7 +587,7 @@ end
 ```
 
 - `get(String appName)` returns the running app with the given name, returns `undefined` if the app is not currently running
-- `launch(String appName)` launches to the background and returns the app with the given name, returns `undefined` if unsuccessful
+- `launch(String appName, Map<String, AnyObject> optionals)` launches and returns the app with the given name, returns `undefined` if unsuccessful
 - `focused()` returns the focused app
 - `all()` returns all running apps
 - `processIdentifier()` returns the process identifier (PID) for the app, returns `-1` if the app does not have a PID
@@ -612,6 +612,10 @@ end
 ### Terminate Optionals
 
 - `force` (boolean): if set `true` force terminates the app
+
+### Launch Optionals
+
+- `focus` (boolean): if set `true`, the launched app will be automatically focused. You don't need to call app.focus() to bring it forward.
 
 ## 21. Window
 


### PR DESCRIPTION
app.launch() now takes an extra options parameter. If `focus` is set to
true, then OC code will use NSWorkspaceLaunchDefault instead of
NSWorkspaceLaunchWithoutActivation to call launchApplicationAtURL. The
launched app will auto focus, and the speed will be noticeably faster.

- [x] Updated related documentations
- [ ] Added the change to the Changelog
