### PR TITLE
Add modifier flags for mouse events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Release: dd.mm.yyyy
 #### App
 
 - Change: Function `launch(...)` now supports a focus option to focus the app automatically on launch ([#211](https://github.com/kasper/phoenix/issues/211), [#212](https://github.com/kasper/phoenix/pull/212)).
+- New: Add modifier flags to mouse events ([#216](https://github.com/kasper/phoenix/issues/216)).
 
 2.6.1
 -----

--- a/Phoenix/PHGlobalEventMonitor.m
+++ b/Phoenix/PHGlobalEventMonitor.m
@@ -6,6 +6,7 @@
 
 #import "PHEventConstants.h"
 #import "PHGlobalEventMonitor.h"
+#import "PHKeyTranslator.h"
 #import "PHMouse.h"
 
 @interface PHGlobalEventMonitor ()
@@ -98,7 +99,12 @@
             // Event for mouse
             if ([notification hasPrefix:NSStringFromClass([PHMouse class])]) {
                 CGPoint location = [PHMouse location];
-                userInfo[PHGlobalEventMonitorMouseKey] = @{ @"x": @(location.x), @"y": @(location.y) };
+                NSArray<NSString *> *modifiers = [PHKeyTranslator modifiersForModifierFlags:event.modifierFlags];
+                userInfo[PHGlobalEventMonitorMouseKey] = @{
+                   @"x": @(location.x),
+                   @"y": @(location.y),
+                   @"modifiers": modifiers,
+               };
             }
 
             [[NSNotificationCenter defaultCenter] postNotificationName:notification object:nil userInfo:userInfo];

--- a/Phoenix/PHKeyTranslator.h
+++ b/Phoenix/PHKeyTranslator.h
@@ -12,6 +12,7 @@
 #pragma mark - Translating
 
 + (UInt32) modifierFlagsForModifiers:(NSArray<NSString *> *)modifiers;
++ (NSArray<NSString *> *) modifiersForModifierFlags:(UInt32)modifierFlags;
 + (UInt32) keyCodeForKey:(NSString *)key;
 
 @end

--- a/Phoenix/PHKeyTranslator.m
+++ b/Phoenix/PHKeyTranslator.m
@@ -3,6 +3,7 @@
  */
 
 @import Carbon;
+@import Cocoa;
 
 #import "PHKeyTranslator.h"
 
@@ -24,6 +25,23 @@
     });
 
     return modifierToFlag[modifier];
+}
+
++ (NSArray<NSString *> *) modifiersForModifierFlags:(UInt32)modifierFlags {
+    NSMutableArray<NSString *> *modifiers = [NSMutableArray array];
+    if (modifierFlags & NSEventModifierFlagCommand) {
+        [modifiers addObject:@"cmd"];
+    }
+    if (modifierFlags & NSEventModifierFlagOption) {
+        [modifiers addObject:@"alt"];
+    }
+    if (modifierFlags & NSEventModifierFlagControl) {
+        [modifiers addObject:@"ctrl"];
+    }
+    if (modifierFlags & NSEventModifierFlagShift) {
+        [modifiers addObject:@"shift"];
+    }
+    return modifiers;
 }
 
 #pragma mark - Local Key

--- a/docs/API.md
+++ b/docs/API.md
@@ -160,7 +160,7 @@ Phoenix supports the following (case sensitive) events:
 
 ### Mouse
 
-All of the following mouse events receive the corresponding `Point`-object as the first argument for the callback function.
+All of the following mouse events receive the corresponding `Point`-object as the first argument for the callback function. The object will also contain a `modifiers` arrays which will contain the modifier keys pressed when the mouse event occurred.
 
 - `mouseDidMove` triggered when the mouse has moved
 - `mouseDidLeftClick` triggered when the mouse did left click


### PR DESCRIPTION
This adds modifier flags for mouse events (fixes #216), allowing you to do things like this (which would be useful for when I lose my mouse cursor):

```js
// If I Cmd+Alt+Click, centre my mouse cursor on the main screen.
var handler = new Event('mouseDidLeftClick', function (event) {
    if (_.includes(event.modifiers, 'cmd') && _.includes(event.modifiers, 'alt')) {
        var mainScreen = Screen.all()[0];
        var mainScreenFrame = mainScreen.frame();
        var middle = { 
            x: mainScreenFrame.x + mainScreenFrame.width / 2,
            y: mainScreenFrame.y + mainScreenFrame.height / 2,
        };
        Mouse.move(middle);
    }
});
```

- [x] Updated related documentations
- [x] Added the change to the Changelog
