### PR TITLE
ADD PHIcon class

### DIFF
--- a/Phoenix.xcodeproj/project.pbxproj
+++ b/Phoenix.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1C93D6641BE11FF100649405 /* PHShebangPreprocessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C93D6631BE11FF100649405 /* PHShebangPreprocessor.m */; };
+		72A76ECA217684220007AE96 /* PHIcon.m in Sources */ = {isa = PBXBuildFile; fileRef = 72A76EC8217684220007AE96 /* PHIcon.m */; };
 		A7183B671B6E865F00842E13 /* PHKeyHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = A7183B661B6E865F00842E13 /* PHKeyHandler.m */; };
 		A7288A351CC119BD00EC032B /* PHTimerHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = A7288A341CC119BD00EC032B /* PHTimerHandler.m */; };
 		A7288A3B1CC14DF800EC032B /* PHWeakTimerTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = A7288A3A1CC14DF800EC032B /* PHWeakTimerTarget.m */; };
@@ -64,6 +65,8 @@
 		14DA76905814ABA3258EF84C /* Pods-Phoenix.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Phoenix.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Phoenix/Pods-Phoenix.debug.xcconfig"; sourceTree = "<group>"; };
 		1C93D6621BE11FF100649405 /* PHShebangPreprocessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PHShebangPreprocessor.h; sourceTree = "<group>"; };
 		1C93D6631BE11FF100649405 /* PHShebangPreprocessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PHShebangPreprocessor.m; sourceTree = "<group>"; };
+		72A76EC8217684220007AE96 /* PHIcon.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PHIcon.m; path = /Users/pierre.borckmans/Dev/Perso/phoenix/Phoenix/PHIcon.m; sourceTree = "<absolute>"; };
+		72A76EC9217684220007AE96 /* PHIcon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PHIcon.h; path = /Users/pierre.borckmans/Dev/Perso/phoenix/Phoenix/PHIcon.h; sourceTree = "<absolute>"; };
 		A7183B651B6E865F00842E13 /* PHKeyHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PHKeyHandler.h; sourceTree = "<group>"; };
 		A7183B661B6E865F00842E13 /* PHKeyHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PHKeyHandler.m; sourceTree = "<group>"; };
 		A7288A331CC119BD00EC032B /* PHTimerHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PHTimerHandler.h; sourceTree = "<group>"; };
@@ -198,6 +201,8 @@
 				A731A7251C2C76B800EB9FD5 /* PHSpace.m */,
 				A79C46901B5BF3C100C460CF /* PHWindow.h */,
 				A79C46911B5BF3C100C460CF /* PHWindow.m */,
+				72A76EC9217684220007AE96 /* PHIcon.h */,
+				72A76EC8217684220007AE96 /* PHIcon.m */,
 			);
 			name = Elements;
 			sourceTree = "<group>";
@@ -576,6 +581,7 @@
 				A74133721BB7F556008DAF39 /* PHEventTranslator.m in Sources */,
 				A7E6DF6F1BBAC1F3001920B4 /* PHAccessibilityObserver.m in Sources */,
 				A79C46971B5BF3C100C460CF /* PHApp.m in Sources */,
+				72A76ECA217684220007AE96 /* PHIcon.m in Sources */,
 				1C93D6641BE11FF100649405 /* PHShebangPreprocessor.m in Sources */,
 				A7D1D9A91B6FD6A300E00CC9 /* PHKeyTranslator.m in Sources */,
 				A78566D11CBE77CD00036AF9 /* PHPreferences.m in Sources */,

--- a/Phoenix.xcodeproj/project.pbxproj
+++ b/Phoenix.xcodeproj/project.pbxproj
@@ -65,8 +65,8 @@
 		14DA76905814ABA3258EF84C /* Pods-Phoenix.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Phoenix.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Phoenix/Pods-Phoenix.debug.xcconfig"; sourceTree = "<group>"; };
 		1C93D6621BE11FF100649405 /* PHShebangPreprocessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PHShebangPreprocessor.h; sourceTree = "<group>"; };
 		1C93D6631BE11FF100649405 /* PHShebangPreprocessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PHShebangPreprocessor.m; sourceTree = "<group>"; };
-		72A76EC8217684220007AE96 /* PHIcon.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PHIcon.m; path = /Users/pierre.borckmans/Dev/Perso/phoenix/Phoenix/PHIcon.m; sourceTree = "<absolute>"; };
-		72A76EC9217684220007AE96 /* PHIcon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PHIcon.h; path = /Users/pierre.borckmans/Dev/Perso/phoenix/Phoenix/PHIcon.h; sourceTree = "<absolute>"; };
+		72A76EC8217684220007AE96 /* PHIcon.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PHIcon.m; path = PHIcon.m; sourceTree = "<group>"; };
+		72A76EC9217684220007AE96 /* PHIcon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PHIcon.h; path = PHIcon.h; sourceTree = "<group>"; };
 		A7183B651B6E865F00842E13 /* PHKeyHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PHKeyHandler.h; sourceTree = "<group>"; };
 		A7183B661B6E865F00842E13 /* PHKeyHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PHKeyHandler.m; sourceTree = "<group>"; };
 		A7288A331CC119BD00EC032B /* PHTimerHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PHTimerHandler.h; sourceTree = "<group>"; };

--- a/Phoenix/PHContext.m
+++ b/Phoenix/PHContext.m
@@ -23,6 +23,7 @@
 #import "PHTaskHandler.h"
 #import "PHTimerHandler.h"
 #import "PHWindow.h"
+#import "PHIcon.h"
 
 @interface PHContext ()
 
@@ -191,6 +192,7 @@
     self.context[@"Mouse"] = [PHMouse class];
     self.context[@"App"] = [PHApp class];
     self.context[@"Window"] = [PHWindow class];
+    self.context[@"Icon"] = [PHIcon class];
 
     self.context[@"require"] = ^(NSString *path) {
 

--- a/Phoenix/PHIcon.h
+++ b/Phoenix/PHIcon.h
@@ -10,7 +10,6 @@
 
 @protocol PHIconJSExport <JSExport, PHIdentifiableJSExport>
 
-#pragma mark - Properties
 + (NSImage *) getFromFile:(NSString *)path;
 + (NSImage *) getFromFile:(NSString *)path withWidth:(int)width;
 + (NSImage *) getFromFile:(NSString *)path withHeight:(int) height;
@@ -19,7 +18,5 @@
 @end
 
 @interface PHIcon : PHAXUIElement <PHIconJSExport>
-
-#pragma mark - Initialising
 
 @end

--- a/Phoenix/PHIcon.h
+++ b/Phoenix/PHIcon.h
@@ -1,0 +1,25 @@
+/*
+ * Phoenix is released under the MIT License. Refer to https://github.com/kasper/phoenix/blob/master/LICENSE.md
+ */
+
+@import Cocoa;
+@import JavaScriptCore;
+
+#import "PHAXUIElement.h"
+#import "PHIdentifiableJSExport.h"
+
+@protocol PHIconJSExport <JSExport, PHIdentifiableJSExport>
+
+#pragma mark - Properties
++ (NSImage *) getFromFile:(NSString *)path;
++ (NSImage *) getFromFile:(NSString *)path withWidth:(int)width;
++ (NSImage *) getFromFile:(NSString *)path withHeight:(int) height;
++ (NSImage *) set:(NSImage*)anImage Width:(int)newWidth AndHeight:(int)newHeight;
+
+@end
+
+@interface PHIcon : PHAXUIElement <PHIconJSExport>
+
+#pragma mark - Initialising
+
+@end

--- a/Phoenix/PHIcon.m
+++ b/Phoenix/PHIcon.m
@@ -11,7 +11,7 @@
 @implementation PHIcon
 
 + (NSImage *) set:(NSImage*)anImage Width:(int)newWidth AndHeight:(int)newHeight {
-    NSImage *sourceImage = anImage;
+    NSImage *sourceImage = anImage.copy;
     
     // Report an error if the source isn't a valid image
     if (![sourceImage isValid]){
@@ -22,10 +22,9 @@
         newSize.height = newHeight;
         NSImage *smallImage = [[NSImage alloc] initWithSize: newSize];
         [smallImage lockFocus];
-        NSImage* copy = sourceImage.copy;
-        [copy setSize: newSize];
+        [sourceImage setSize: newSize];
         [[NSGraphicsContext currentContext] setImageInterpolation:NSImageInterpolationHigh];
-        [copy drawAtPoint:NSZeroPoint fromRect:CGRectMake(0, 0, newSize.width, newSize.height) operation:NSCompositeCopy fraction:1.0];
+        [sourceImage drawAtPoint:NSZeroPoint fromRect:CGRectMake(0, 0, newSize.width, newSize.height) operation:NSCompositeCopy fraction:1.0];
         [smallImage unlockFocus];
         return smallImage;
     }

--- a/Phoenix/PHIcon.m
+++ b/Phoenix/PHIcon.m
@@ -1,0 +1,54 @@
+/*
+ * Phoenix is released under the MIT License. Refer to https://github.com/kasper/phoenix/blob/master/LICENSE.md
+ */
+
+#import "PHIcon.h"
+
+@interface PHIcon ()
+
+@end
+
+@implementation PHIcon
+
++ (NSImage *) set:(NSImage*)anImage Width:(int)newWidth AndHeight:(int)newHeight {
+    NSImage *sourceImage = anImage;
+    
+    // Report an error if the source isn't a valid image
+    if (![sourceImage isValid]){
+        NSLog(@"Invalid Image");
+    } else {
+        NSSize newSize;
+        newSize.width = newWidth;
+        newSize.height = newHeight;
+        NSImage *smallImage = [[NSImage alloc] initWithSize: newSize];
+        [smallImage lockFocus];
+        NSImage* copy = sourceImage.copy;
+        [copy setSize: newSize];
+        [[NSGraphicsContext currentContext] setImageInterpolation:NSImageInterpolationHigh];
+        [copy drawAtPoint:NSZeroPoint fromRect:CGRectMake(0, 0, newSize.width, newSize.height) operation:NSCompositeCopy fraction:1.0];
+        [smallImage unlockFocus];
+        return smallImage;
+    }
+    return nil;
+}
+
++ (NSImage *) getFromFile:(NSString *)path withWidth:(int) width {
+    NSImage* icon = [[NSImage alloc]initWithContentsOfFile:path];
+    double ratio = icon.size.width / icon.size.height;
+    int height = width*ratio;
+    return [self set:icon Width:width AndHeight:height];
+}
+
++ (NSImage *) getFromFile:(NSString *)path withHeight:(int) height {
+    NSImage* icon = [[NSImage alloc]initWithContentsOfFile:path];
+    double ratio = icon.size.width / icon.size.height;
+    int width = height/ratio;
+    return [self set:icon Width:width AndHeight:height];
+}
+
++ (NSImage *) getFromFile:(NSString *)path {
+    NSImage* icon = [[NSImage alloc]initWithContentsOfFile:path];
+    return icon;
+}
+
+@end


### PR DESCRIPTION
Hi @kasper,

As discussed in #226, I have given a very first raw shot at adding a new `Icon` class.

Could you please have a quick look, as my experience with Objective C is rather limited.

This PR does the trick for me, as I'm able to use the following new functions:
```
var icon = Icon.getFromFile("/absolute/path/to/an/image/file")
var iconWithWidth = Icon.getFromFileWithWidth("/absolute/path/to/an/image/file", 48)
var iconWithHeight = Icon.getFromFileWithHeight("/absolute/path/to/an/image/file", 150)
var iconResized = Icon.setWidthAndHeight(icon,48,48);
```

I'm then able to use that icon in a modal as depicted below:
![image](https://user-images.githubusercontent.com/5610359/47046934-a0549f00-d196-11e8-8a60-acd1cb043987.png)



If you think this is a good basis, then I'm happy to proceed with:
- robustness (non existing/corrupted/... files)
- adding base64-encoded images loading
- updating documentation
- adding tests
