### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A lightweight macOS window and app manager scriptable with JavaScript. You can a
 
 To install, extract the downloaded archive and just drag-and-drop Phoenix to your `Applications`-folder. When you run Phoenix for the first time, you will be asked to allow it to control your UI. macOS will ask you to open `Security & Privacy` in System Preferences. Once open, go to the `Accessibility`-section and click the checkbox next to Phoenix to enable control. An admin account is required to accomplish this.
 
-Alternatively, if you have [Homebrew Cask](https://caskroom.github.io) installed, you can simply run `brew cask install phoenix`.
+Alternatively, if you have [Homebrew Cask](https://caskroom.github.io) installed, you can simply run `brew install --cask phoenix`.
 
 ## Uninstall
 


### PR DESCRIPTION
Fix error when installing using latest Homebrew. This is not a bug of this app, but README.md needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103144574-4a64e400-476f-11eb-82e4-1e389052a165.png)

These are not relevant since it’s a simple README change:
- [ ] Updated related documentations
- [ ] Added the change to the Changelog
