### PR TITLE
apple script proof of concept

### DIFF
--- a/Phoenix.xcodeproj/project.pbxproj
+++ b/Phoenix.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		A7E6DF6F1BBAC1F3001920B4 /* PHAccessibilityObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = A7E6DF6E1BBAC1F3001920B4 /* PHAccessibilityObserver.m */; };
 		A7F24F5F1C2728540013EBAE /* NSTask+PHExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = A7F24F5E1C2728540013EBAE /* NSTask+PHExtension.m */; };
 		B1CB3438E933A38FD2BBF573 /* libPods-Phoenix.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC5342E0734A711231D71BF1 /* libPods-Phoenix.a */; };
+		E868C1B1265A82CD00AC8F4D /* Phoenix.sdef in Resources */ = {isa = PBXBuildFile; fileRef = E868C1B0265A82CD00AC8F4D /* Phoenix.sdef */; };
+		E8FC82AF265FC9F700F66151 /* PHDispatchCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = E8FC82AE265FC9F700F66151 /* PHDispatchCommand.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -147,6 +149,9 @@
 		A7F24F5E1C2728540013EBAE /* NSTask+PHExtension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSTask+PHExtension.m"; sourceTree = "<group>"; };
 		DC5342E0734A711231D71BF1 /* libPods-Phoenix.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Phoenix.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DF23C77C388EEDB5B63E6130 /* Pods-Phoenix.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Phoenix.release.xcconfig"; path = "Pods/Target Support Files/Pods-Phoenix/Pods-Phoenix.release.xcconfig"; sourceTree = "<group>"; };
+		E868C1B0265A82CD00AC8F4D /* Phoenix.sdef */ = {isa = PBXFileReference; lastKnownFileType = text; path = Phoenix.sdef; sourceTree = "<group>"; };
+		E8FC82AE265FC9F700F66151 /* PHDispatchCommand.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PHDispatchCommand.m; sourceTree = "<group>"; };
+		E8FC82B0265FCA3A00F66151 /* PHDispatchCommand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PHDispatchCommand.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -328,6 +333,7 @@
 		A79C46591B5BF31100C460CF /* Phoenix */ = {
 			isa = PBXGroup;
 			children = (
+				E8FC82B2266258B600F66151 /* AppleScript */,
 				A7C3C2F823DB8D7E00FAEFED /* Phoenix.entitlements */,
 				A77952C41BBE7CCD00FC8D38 /* Accessibility */,
 				A77952C71BBE7E3E00FC8D38 /* Context */,
@@ -344,6 +350,7 @@
 				A7EBD1C11BFDF7E1000D8E5F /* Preprocessors */,
 				A79C465A1B5BF31100C460CF /* Supporting Files */,
 				A73FF10C1BBD8F350024CF97 /* Translators */,
+				E868C1B0265A82CD00AC8F4D /* Phoenix.sdef */,
 			);
 			path = Phoenix;
 			sourceTree = "<group>";
@@ -386,6 +393,15 @@
 				1C93D6631BE11FF100649405 /* PHShebangPreprocessor.m */,
 			);
 			name = Preprocessors;
+			sourceTree = "<group>";
+		};
+		E8FC82B2266258B600F66151 /* AppleScript */ = {
+			isa = PBXGroup;
+			children = (
+				E8FC82B0265FCA3A00F66151 /* PHDispatchCommand.h */,
+				E8FC82AE265FC9F700F66151 /* PHDispatchCommand.m */,
+			);
+			name = AppleScript;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -480,6 +496,7 @@
 				A79B89E01B5E74C1004DDE82 /* MainMenu.xib in Resources */,
 				A77AB3261DD73F00003B5872 /* lodash.min.js in Resources */,
 				A7952E7E1C0721850062D651 /* dsa-phoenix-pub.pem in Resources */,
+				E868C1B1265A82CD00AC8F4D /* Phoenix.sdef in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -590,6 +607,7 @@
 				A72EAD071B5D00B800DD537B /* PHModalWindowController.m in Sources */,
 				A741336C1BB7EEAC008DAF39 /* PHHandler.m in Sources */,
 				A741336F1BB7F228008DAF39 /* PHEventHandler.m in Sources */,
+				E8FC82AF265FC9F700F66151 /* PHDispatchCommand.m in Sources */,
 				A7741A291D2BBF55009E8A2F /* PHGlobalEventMonitor.m in Sources */,
 				A7F24F5F1C2728540013EBAE /* NSTask+PHExtension.m in Sources */,
 				A7183B671B6E865F00842E13 /* PHKeyHandler.m in Sources */,

--- a/Phoenix/Info.plist
+++ b/Phoenix/Info.plist
@@ -28,12 +28,16 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>NSAppleScriptEnabled</key>
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2013 Steven Degutis, 2014 Jason Milkins and 2015 Kasper Hirvikoski.</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>OSAScriptingDefinition</key>
+	<string>Phoenix.sdef</string>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUFeedURL</key>

--- a/Phoenix/PHDispatchCommand.h
+++ b/Phoenix/PHDispatchCommand.h
@@ -1,0 +1,11 @@
+/*
+ * Phoenix is released under the MIT License. Refer to https://github.com/kasper/phoenix/blob/master/LICENSE.md
+ */
+
+@import Cocoa;
+
+@interface PHDispatchCommand : NSScriptCommand
+
+- (id) performDefaultImplementation;
+
+@end

--- a/Phoenix/PHDispatchCommand.m
+++ b/Phoenix/PHDispatchCommand.m
@@ -1,0 +1,20 @@
+/*
+ * Phoenix is released under the MIT License. Refer to https://github.com/kasper/phoenix/blob/master/LICENSE.md
+ */
+
+#import "PHDispatchCommand.h"
+#import "PHEventConstants.h"
+
+@implementation PHDispatchCommand
+
+- (id) performDefaultImplementation {
+    NSMutableDictionary* notificationParameters = [NSMutableDictionary dictionary];
+    NSString* data = [[self evaluatedArguments] objectForKey:@"data"];
+    if (data) {
+        notificationParameters[PHAppleScriptDispatchNotification] = data;
+    }
+    [[NSNotificationCenter defaultCenter] postNotificationName:PHAppleScriptDispatchNotification object:nil userInfo:notificationParameters];
+    return nil;
+}
+
+@end

--- a/Phoenix/PHEventConstants.h
+++ b/Phoenix/PHEventConstants.h
@@ -16,3 +16,7 @@ static NSString * const PHMouseDidLeftClickNotification = @"PHMouseDidLeftClickN
 static NSString * const PHMouseDidRightClickNotification = @"PHMouseDidRightClickNotification";
 static NSString * const PHMouseDidLeftDragNotification = @"PHMouseDidLeftDragNotification";
 static NSString * const PHMouseDidRightDragNotification = @"PHMouseDidRightDragNotification";
+
+#pragma mark - Apple scripting notifications
+
+static NSString * const PHAppleScriptDispatchNotification = @"PHDispatchNotification";

--- a/Phoenix/PHEventHandler.m
+++ b/Phoenix/PHEventHandler.m
@@ -10,6 +10,7 @@
 #import "PHEventTranslator.h"
 #import "PHGlobalEventMonitor.h"
 #import "PHWindow.h"
+#import "PHEventConstants.h"
 
 @interface PHEventHandler ()
 
@@ -69,6 +70,7 @@
     NSDictionary<NSString *, id> *mouse = notification.userInfo[PHGlobalEventMonitorMouseKey];
     NSRunningApplication *runningApp = notification.userInfo[NSWorkspaceApplicationKey];
     PHWindow *window = notification.userInfo[PHAXObserverWindowKey];
+    NSString *dispatchData = notification.userInfo[PHAppleScriptDispatchNotification];
 
     // Notification for mouse
     if (mouse) {
@@ -86,6 +88,12 @@
     // Notification for window
     if (window) {
         [self callWithArguments:@[ window, self ]];
+        return;
+    }
+
+    // AppleScript Dispatch event with data
+    if (dispatchData) {
+        [self callWithArguments:@[ self, dispatchData ]];
         return;
     }
 

--- a/Phoenix/PHEventTranslator.m
+++ b/Phoenix/PHEventTranslator.m
@@ -70,6 +70,10 @@
                                  @"mouseDidRightClick": PHMouseDidRightClickNotification,
                                  @"mouseDidLeftDrag": PHMouseDidLeftDragNotification,
                                  @"mouseDidRightDrag": PHMouseDidRightDragNotification,
+                                 
+                                 /* Apple Scripting Notifications */
+
+                                 @"dispatch": PHAppleScriptDispatchNotification,
 
                                  /* App Notifications */
 

--- a/Phoenix/Phoenix.sdef
+++ b/Phoenix/Phoenix.sdef
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE dictionary SYSTEM "file://localhost/System/Library/DTDs/sdef.dtd">
+
+<dictionary title="Standard Terminology">
+    
+    <suite name="Phoenix Suite" code="PhSu" description="Phoenix suite.">
+        
+        <class name="application" code="capp" description="The application's top level scripting object.">
+            <cocoa class="NSApplication"/>
+        </class>
+        
+        <command name="dispatch" code="aevtdisp" description="Dispatch an application event.">
+            <cocoa class="PHDispatchCommand"/>
+
+            <parameter name="event with" code="eVnW" type="text" optional="yes" description="optional event data">
+                <cocoa key="data"/>
+            </parameter>
+        </command>
+        
+    </suite>
+  
+</dictionary>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "version": "2.6.8",
       "devDependencies": {
+        "at-least-node": "1.0.0",
         "eslint-config-airbnb-base": "14.2.1",
         "uglify-js": "3.13.7",
         "xo": "0.40.1"
@@ -998,6 +999,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/atob": {
@@ -2361,7 +2371,7 @@
       "integrity": "sha512-MiO3vyF5CRhGwEwNmwq+7PPgc1kYsDCQyt010vXOQJTXbJctjRytzvE8fFgs4X7MCjgtkj1sgrhDyZPVICjAAA==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2800,7 +2810,7 @@
       "integrity": "sha512-NGmI6BH5L12pl7ScQHbg7tvtk4wPxxj8yPHH47NvSmMtFneC077PSeY3huFj06ZWZvtbfxSPt3RuOQD5XcR4ng==",
       "dev": true,
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=6"
       },
       "peerDependencies": {
         "eslint": "^7.0.0"
@@ -2827,7 +2837,7 @@
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
@@ -3580,7 +3590,7 @@
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       }
     },
     "node_modules/fs.realpath": {
@@ -5357,7 +5367,7 @@
         "picomatch": "^2.2.3"
       },
       "engines": {
-        "node": ">=8.6"
+        "node": ">=8"
       }
     },
     "node_modules/miller-rabin": {
@@ -8058,7 +8068,7 @@
         "xo": "cli.js"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=10.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8898,6 +8908,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
     "atob": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "npm": ">=7.14.0"
   },
   "devDependencies": {
+    "at-least-node": "1.0.0",
     "eslint-config-airbnb-base": "14.2.1",
     "uglify-js": "3.13.7",
     "xo": "0.40.1"


### PR DESCRIPTION
- [ ] Updated related documentations
- [ ] Added the change to the Changelog

Hi there,
I'd like to share with you this proof-of-concept Apple Script integration, where you can call an Event in your javascript config via an Apple Script.

__NOTE__ This PR is not in any shape to be merged, and I would like your guidance as to how best to implement this feature if you consider it worthwhile pursuing.

The following is an example javascript config:
```js
const event = new Event('dispatch', function (event, data) {
  const text = data
    ? 'Event from AppleScript with data: ' + data
    : 'Event from AppleScript';

  Modal.build({ duration: 5, text }).show();
});
```

And the following is an example Apple Script:
```applescript
tell application "Phoenix"
  dispatch
  dispatch event with "testing testing 1 2 3"
end tell
```

You could also run the following from the command line:
```bash
osascript -e 'tell application "Phoenix" to dispatch'
```

Properly implemented, this could address the following issues:
- https://github.com/kasper/phoenix/issues/215
- https://github.com/kasper/phoenix/issues/140

So what do you think, is this worth pursuing?