### PR TITLE
Add App.open() method

### DIFF
--- a/Phoenix/PHApp.h
+++ b/Phoenix/PHApp.h
@@ -19,6 +19,7 @@ static NSString * const PHAppFocusOptionKey = @"focus";
 
 + (instancetype) get:(NSString *)appName;
 JSExportAs(launch, + (instancetype) launch:(NSString *)appName withOptionals:(NSDictionary<NSString *, id> *)optionals);
+JSExportAs(open, + (instancetype) open:(NSString *)filePath withOptionals:(NSDictionary<NSString *, id> *)optionals);
 + (instancetype) focused;
 + (NSArray<PHApp *> *) all;
 

--- a/Phoenix/PHApp.m
+++ b/Phoenix/PHApp.m
@@ -42,17 +42,9 @@ static NSString * const PHAppForceOptionKey = @"force";
     return nil;
 }
 
-+ (instancetype) launch:(NSString *)appName withOptionals:(NSDictionary<NSString *, id> *)optionals {
-
++ (instancetype) open:(NSString *)filePath withOptionals:(NSDictionary<NSString *, id> *)optionals {
     NSWorkspace *sharedWorkspace = [NSWorkspace sharedWorkspace];
-    NSString *appPath = [sharedWorkspace fullPathForApplication:appName];
     NSWorkspaceLaunchOptions launchOptions = NSWorkspaceLaunchWithoutActivation;
-
-    if (!appPath) {
-        NSLog(@"Error: Could not find an app with the name “%@”.", appName);
-        return nil;
-    }
-
     NSNumber *focusOption = optionals[PHAppFocusOptionKey];
 
     // Focus on launch
@@ -61,16 +53,23 @@ static NSString * const PHAppForceOptionKey = @"force";
     }
 
     NSError *error;
-    NSRunningApplication *app = [sharedWorkspace launchApplicationAtURL:[NSURL fileURLWithPath:appPath]
+    NSRunningApplication *app = [sharedWorkspace openURL:[NSURL fileURLWithPath:filePath]
                                                                 options:launchOptions
-                                                          configuration:@{}
-                                                                  error:&error];
+                                                                configuration:@{}
+                                                                error:&error];
     if (error) {
-        NSLog(@"Error: Could not launch app “%@”. (%@)", appName, error);
+        NSLog(@"Error: Could not open file “%@”. (%@)", filePath, error);
         return nil;
     }
 
     return [[self alloc] initWithApp:app];
+}
+
++ (instancetype) launch:(NSString *)appName withOptionals:(NSDictionary<NSString *, id> *)optionals {
+    NSWorkspace *sharedWorkspace = [NSWorkspace sharedWorkspace];
+    NSString *appPath = [sharedWorkspace fullPathForApplication:appName];
+
+    return [self open:appPath withOptionals:optionals];
 }
 
 + (instancetype) focused {


### PR DESCRIPTION
Opens a file with the default associated app, instead of launching an app. Useful to open files/directories via keyboard shortcuts. My specific use-case was to open my “Downloads” directory.

From developer interface standpoint, having those two methods makes sense, but I am happy to hear any feedback since we are increasing the API surface.

Implementation notes:

* Since opening an .app file by default launches it, the `App.launch()` method uses this one internally. Based on the docs, it should work equally well.
* Since the old code was using the deprecated `launchApplicationAtURL`, I used its counterpart, `openURL`. I am super new to Apple APIs, so decided to stick with what works, but I am happy to switch to something that's not deprecated. To be honest, I didn't have time to dig into the trade-offs of the various alternatives, like `open`.
* We are losing a bit of fidelity in the error message, though it sounds acceptable to me.

Thank you for the great project :)

If the maintainers think the change makes sense, I am happy to add docs/changelog entry.

- [ ] Updated related documentations
- [ ] Added the change to the Changelog
