### PR TITLE
Disable AXEnhancedUserInterface temporarily while moving or resizing windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Changelog
 
 Release: dd.mm.yyyy
 
+### Bug Fixes
+
+- Fix issue that prevented moving or resizing some windows properly. Notably, this fixes issues and makes the window movement immediate with Google Chrome windows ([#301](https://github.com/kasper/phoenix/issues/301)).
+
 3.0.0
 -----
 


### PR DESCRIPTION
- [ ] ~Updated related documentations~ (nothing to update)
- [x] Added the change to the Changelog

Should fix #301.

There is an issue with some applications not wanting to respect moving or resizing properly. Most notably, this affects Google Chrome. There is a long discussion about a similar issue with Rectangle here: https://github.com/rxhanson/Rectangle/issues/165

And their current approach to fix the issue is here (which I followed loosely): https://github.com/rxhanson/Rectangle/blob/95019b71e8dde1ff7e52f660788fe4f44e3fab14/Rectangle/AccessibilityElement.swift#L146

This was my first time writing Objective C, so be gentle. Tested in macOS 12.2.1.

PS. hi Kasper, maybe you remember me! This is a very useful app for trying to get a more keyboard-oriented workflow going on macOS after being used to everything convenient in i3 :-)