### PR TITLE
Fix Space#moveWindows on Sonoma 14.5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Changelog
 
 Release: dd.mm.yyyy
 
+### Bug Fixes
+
+- Fix `Space#moveWindows` on Sonoma 14.5 ([#348](https://github.com/kasper/phoenix/issues/348), [#349](https://github.com/kasper/phoenix/issues/349)).
+
 4.0.0
 -----
 

--- a/Phoenix/NSProcessInfo+PHExtension.h
+++ b/Phoenix/NSProcessInfo+PHExtension.h
@@ -10,6 +10,6 @@
 
 + (BOOL)isOperatingSystemAtLeastBigSur;
 + (BOOL)isOperatingSystemAtLeastMonterey;
-+ (BOOL)canMoveWindowsToManagedSpace;
++ (BOOL)isOperatingSystemAtLeastSonoma145;
 
 @end

--- a/Phoenix/NSProcessInfo+PHExtension.h
+++ b/Phoenix/NSProcessInfo+PHExtension.h
@@ -10,5 +10,6 @@
 
 + (BOOL)isOperatingSystemAtLeastBigSur;
 + (BOOL)isOperatingSystemAtLeastMonterey;
++ (BOOL)canMoveWindowsToManagedSpace;
 
 @end

--- a/Phoenix/NSProcessInfo+PHExtension.m
+++ b/Phoenix/NSProcessInfo+PHExtension.m
@@ -18,9 +18,9 @@
     return [[self processInfo] isOperatingSystemAtLeastVersion:monterey];
 }
 
-+ (BOOL)canMoveWindowsToManagedSpace {
++ (BOOL)isOperatingSystemAtLeastSonoma145 {
     NSOperatingSystemVersion sonoma145 = {.majorVersion = 14, .minorVersion = 5, .patchVersion = 0};
-    return ![[self processInfo] isOperatingSystemAtLeastVersion:sonoma145];
+    return [[self processInfo] isOperatingSystemAtLeastVersion:sonoma145];
 }
 
 @end

--- a/Phoenix/NSProcessInfo+PHExtension.m
+++ b/Phoenix/NSProcessInfo+PHExtension.m
@@ -18,4 +18,9 @@
     return [[self processInfo] isOperatingSystemAtLeastVersion:monterey];
 }
 
++ (BOOL)canMoveWindowsToManagedSpace {
+    NSOperatingSystemVersion sonoma145 = {.majorVersion = 14, .minorVersion = 5, .patchVersion = 0};
+    return ![[self processInfo] isOperatingSystemAtLeastVersion:sonoma145];
+}
+
 @end

--- a/Phoenix/PHSpace.m
+++ b/Phoenix/PHSpace.m
@@ -72,7 +72,7 @@ void CGSMoveWindowsToManagedSpace(CGSConnectionID connection, CFArrayRef windowI
 // XXX: Undocumented private API to set a space’s (legacy) compatId
 CGError CGSSpaceSetCompatID(CGSConnectionID connection, CGSSpaceID spaceId, CGSMoveWindowCompatID compatID);
 
-// XXX: Undocumented private API to move the given windows (CGWindowIDs) to the given space by (legacy) compatId
+// XXX: Undocumented private API to move the given windows (CGWindowIDs) to the given space by its (legacy) compatId
 CGError CGSSetWindowListWorkspace(CGSConnectionID connection,
                                   CGWindowID *windowIds,
                                   NSUInteger windowCount,

--- a/Phoenix/PHSpace.m
+++ b/Phoenix/PHSpace.m
@@ -70,7 +70,7 @@ void CGSRemoveWindowsFromSpaces(CGSConnectionID connection, CFArrayRef windowIds
 void CGSMoveWindowsToManagedSpace(CGSConnectionID connection, CFArrayRef windowIds, CGSSpaceID spaceId);
 
 // XXX: Undocumented private API to set a space’s (legacy) compatId
-CGError CGSSpaceSetCompatID(CGSConnectionID connection, CGSSpaceID spaceId, CGSMoveWindowCompatID compatID);
+CGError CGSSpaceSetCompatID(CGSConnectionID connection, CGSSpaceID spaceId, CGSMoveWindowCompatID compatId);
 
 // XXX: Undocumented private API to move the given windows (CGWindowIDs) to the given space by its (legacy) compatId
 CGError CGSSetWindowListWorkspace(CGSConnectionID connection,
@@ -237,17 +237,6 @@ CGError CGSSetWindowListWorkspace(CGSConnectionID connection,
                                (__bridge CFArrayRef) @[@(self.identifier)]);
 }
 
-- (void)moveWindows:(NSArray<PHWindow *> *)windows {
-    if (![NSProcessInfo isOperatingSystemAtLeastSonoma145]) {
-        CGSMoveWindowsToManagedSpace(
-            CGSMainConnectionID(), (__bridge CFArrayRef)[self identifiersForWindows:windows], self.identifier);
-        return;
-    }
-
-    // CGSMoveWindowsToManagedSpace is broken in MacOS 14.5, so use the legacy Compat ID API instead.
-    [self moveWindowsWithCompatId:windows];
-}
-
 /**
  * - https://github.com/kasper/phoenix/issues/348
  * - https://github.com/koekeishiya/yabai/issues/2240#issuecomment-2116326165
@@ -266,6 +255,17 @@ CGError CGSSetWindowListWorkspace(CGSConnectionID connection,
     CGSSpaceSetCompatID(connection, self.identifier, MoveWindowsCompatId);
     CGSSetWindowListWorkspace(connection, (CGWindowID *)[windowIdSequence bytes], windowCount, MoveWindowsCompatId);
     CGSSpaceSetCompatID(connection, self.identifier, 0x0);
+}
+
+- (void)moveWindows:(NSArray<PHWindow *> *)windows {
+    if (![NSProcessInfo isOperatingSystemAtLeastSonoma145]) {
+        CGSMoveWindowsToManagedSpace(
+            CGSMainConnectionID(), (__bridge CFArrayRef)[self identifiersForWindows:windows], self.identifier);
+        return;
+    }
+
+    // CGSMoveWindowsToManagedSpace is broken in MacOS 14.5, so use the legacy Compat ID API instead.
+    [self moveWindowsWithCompatId:windows];
 }
 
 @end

--- a/Phoenix/PHSpace.m
+++ b/Phoenix/PHSpace.m
@@ -39,7 +39,7 @@ static NSString *const CGSSpaceIDKey = @"ManagedSpaceID";
 static NSString *const CGSSpacesKey = @"Spaces";
 
 // An arbitrary ID we can use with CGSSpaceSetCompatID
-static const CGSMoveWindowCompatID MoveWindowsCompatId = 0x79616265;
+static const CGSMoveWindowCompatID PHMoveWindowsCompatId = 0x79616265;
 
 // XXX: Undocumented private API to get the CGSConnectionID for the default connection for this process
 CGSConnectionID CGSMainConnectionID(void);
@@ -65,8 +65,8 @@ void CGSAddWindowsToSpaces(CGSConnectionID connection, CFArrayRef windowIds, CFA
 // XXX: Undocumented private API to remove the given windows (CGWindowIDs) from the given spaces (CGSSpaceIDs)
 void CGSRemoveWindowsFromSpaces(CGSConnectionID connection, CFArrayRef windowIds, CFArrayRef spaceIds);
 
-// XXX: Undocumented private API to move the given windows (CGWindowIDs) to the given space
-//      Only works prior to MacOS 14.5!
+// XXX: Undocumented private API to move the given windows (CGWindowIDs) to the given space,
+// only works prior to macOS 14.5
 void CGSMoveWindowsToManagedSpace(CGSConnectionID connection, CFArrayRef windowIds, CGSSpaceID spaceId);
 
 // XXX: Undocumented private API to set a space’s (legacy) compatId
@@ -243,17 +243,17 @@ CGError CGSSetWindowListWorkspace(CGSConnectionID connection,
  * - https://github.com/ianyh/Amethyst/issues/1643#issuecomment-2132519682
  */
 - (void)moveWindowsWithCompatId:(NSArray<PHWindow *> *)windows {
-    NSArray<NSNumber *> *ids = [self identifiersForWindows:windows];
-    NSUInteger windowCount = [ids count];
+    NSArray<NSNumber *> *windowIds = [self identifiersForWindows:windows];
+    NSUInteger windowCount = [windowIds count];
     NSMutableData *windowIdSequence = [[NSMutableData alloc] initWithCapacity:windowCount * sizeof(CGWindowID)];
-    for (id item in ids) {
-        CGWindowID value = [item unsignedIntValue];
+    for (NSNumber *item in windowIds) {
+        CGWindowID value = item.unsignedIntValue;
         [windowIdSequence appendBytes:&value length:sizeof(CGWindowID)];
     }
 
     CGSConnectionID connection = CGSMainConnectionID();
-    CGSSpaceSetCompatID(connection, self.identifier, MoveWindowsCompatId);
-    CGSSetWindowListWorkspace(connection, (CGWindowID *)[windowIdSequence bytes], windowCount, MoveWindowsCompatId);
+    CGSSpaceSetCompatID(connection, self.identifier, PHMoveWindowsCompatId);
+    CGSSetWindowListWorkspace(connection, (CGWindowID *)[windowIdSequence bytes], windowCount, PHMoveWindowsCompatId);
     CGSSpaceSetCompatID(connection, self.identifier, 0x0);
 }
 
@@ -264,7 +264,7 @@ CGError CGSSetWindowListWorkspace(CGSConnectionID connection,
         return;
     }
 
-    // CGSMoveWindowsToManagedSpace is broken in MacOS 14.5, so use the legacy Compat ID API instead.
+    // CGSMoveWindowsToManagedSpace is broken in macOS 14.5+, so use the legacy Compat ID API instead
     [self moveWindowsWithCompatId:windows];
 }
 

--- a/Phoenix/PHSpace.m
+++ b/Phoenix/PHSpace.m
@@ -74,7 +74,7 @@ CGError CGSSpaceSetCompatID(CGSConnectionID connection, CGSSpaceID spaceId, CGSM
 
 // XXX: Undocumented private API to move the given windows (CGWindowIDs) to the given space by its (legacy) compatId
 CGError CGSSetWindowListWorkspace(CGSConnectionID connection,
-                                  CGWindowID *windowIds,
+                                  CGWindowID windowIds[],
                                   NSUInteger windowCount,
                                   CGSMoveWindowCompatID compatId);
 

--- a/Phoenix/PHSpace.m
+++ b/Phoenix/PHSpace.m
@@ -246,8 +246,8 @@ CGError CGSSetWindowListWorkspace(CGSConnectionID connection,
     NSArray<NSNumber *> *windowIds = [self identifiersForWindows:windows];
     NSUInteger windowCount = [windowIds count];
     NSMutableData *windowIdSequence = [[NSMutableData alloc] initWithCapacity:windowCount * sizeof(CGWindowID)];
-    for (NSNumber *item in windowIds) {
-        CGWindowID value = item.unsignedIntValue;
+    for (NSNumber *windowId in windowIds) {
+        CGWindowID value = windowId.unsignedIntValue;
         [windowIdSequence appendBytes:&value length:sizeof(CGWindowID)];
     }
 


### PR DESCRIPTION
- [x] Updated related documentations
- [x] Added the change to the Changelog

 Introduce a workaround to CGSMoveWindowsToManagedSpace breaking in MacOS 14.5, based on:

- https://github.com/koekeishiya/yabai/issues/2240#issuecomment-2116326165
- https://github.com/ianyh/Amethyst/issues/1643#issuecomment-2132519682

Fixes #348 and #349.